### PR TITLE
Make function annotations in route handlers work

### DIFF
--- a/bobo/src/bobo.py
+++ b/bobo/src/bobo.py
@@ -50,6 +50,8 @@ _default_content_type = 'text/html; charset=UTF-8'
 
 _json_content_type = re.compile('application/json;?').match
 
+getargspec = inspect.getargspec if six.PY2 else inspect.getfullargspec
+
 class Application:
     """Create a WSGI application.
 
@@ -1172,7 +1174,7 @@ def _make_bobo_handle(func, original, check, content_type):
     return handle
 
 def _make_caller(obj, paramsattr):
-    spec = inspect.getargspec(obj)
+    spec = getargspec(obj)
     nargs = nrequired = len(spec.args)
     if spec.defaults:
         nrequired -= len(spec.defaults)

--- a/bobodoctestumentation/src/bobodoctestumentation/annotations.test
+++ b/bobodoctestumentation/src/bobodoctestumentation/annotations.test
@@ -1,0 +1,27 @@
+====================
+Function Annotations
+====================
+
+There was a bug that would cause things to break when using Python 3
+function annotations in a route handler.  In the future, we could use
+annotations to perform automatic type conversion, but for now we're just
+demonstrating that simply using annotations no longer breaks things.
+
+.. code-block:: python
+
+    import bobo
+    import bobo.testmodule1
+    import webtest
+
+    @bobo.get("/foo/:bar/:baz")
+    def foo(bobo_request, bar:"bar", baz:"baz"):
+        return "OK"
+
+    bobo.testmodule1.foo = foo
+    app = webtest.TestApp(
+            bobo.Application(bobo_resources='bobo.testmodule1'))
+
+We get back the exepcted result when making a request to this route:
+
+    >>> app.get("/foo/1/2")
+    <200 OK text/html body=b'OK'>

--- a/bobodoctestumentation/src/bobodoctestumentation/tests.py
+++ b/bobodoctestumentation/src/bobodoctestumentation/tests.py
@@ -15,6 +15,7 @@
 from zope.testing import doctest, setupstack, renormalizing
 import bobo
 import manuel.capture
+import manuel.codeblock
 import manuel.doctest
 import manuel.testing
 import re
@@ -78,7 +79,7 @@ def test_suite():
         (re.compile("u('.*?')"), r"\1"),
         (re.compile('u(".*?")'), r"\1"),
         ])
-    return unittest.TestSuite((
+    suite = unittest.TestSuite((
         manuel.testing.TestSuite(
             manuel.doctest.Manuel(optionflags=options,
                                   checker=unicode_literal_normalizer) +
@@ -101,3 +102,10 @@ def test_suite():
                 ])
             ),
         ))
+    if not six.PY2:
+        suite.addTest(manuel.testing.TestSuite(
+            manuel.doctest.Manuel() + manuel.codeblock.Manuel(),
+            "annotations.test",
+            setUp=setUp,
+            tearDown=setupstack.tearDown))
+    return suite


### PR DESCRIPTION
In Python 3, calling inspect.getargspec on a function that has
annotations raises an exception.  Instead, you must use
inspect.getfullargspec.
