### PR TITLE
Fix Reload issue when module's path ends in .pyc or .pyo

### DIFF
--- a/bobo/src/boboserver.py
+++ b/bobo/src/boboserver.py
@@ -127,7 +127,10 @@ class Reload:
         self.mtimes = mtimes = {}
         for name in modules.split():
             module = sys.modules[name]
-            mtimes[name] = (module.__file__, os.stat(module.__file__).st_mtime)
+            filename = module.__file__
+            if filename[-4:] in (".pyc", ".pyo"):
+                filename = filename[:-1]
+            mtimes[name] = (filename, os.stat(filename).st_mtime)
 
     def __call__(self, environ, start_response):
         for name, (path, mtime) in sorted(six.iteritems(self.mtimes)):


### PR DESCRIPTION
Occasionally the Reload middleware will cause an exception to be raised when attempting to reload a module:

`
...
File '/Users/patrick/.buildout/eggs/bobo-2.0.0-py2.7.egg/boboserver.py', line 136 in __call__ 
six.exec_(compile(open(path).read(), path, 'exec'), TypeError: compile() expected string without null bytes`

This occurs when the module's path (as given by __file__) does not end in .py (e.g., .pyc or .pyo).

I'm still working on a test case for this that's not totally contrived, but the fix is pretty simple.
