### PR TITLE
Fix Python 2.7 tests: beautifulsoup4

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -30,3 +30,4 @@ eggs = PasteScript
 [versions:python27]
 Sphinx = < 2
 webtest = < 3
+beautifulsoup4 = < 4.10


### PR DESCRIPTION
Current versions no longer support Python 2.7.